### PR TITLE
Fix ancestor confusion in gopath / goroot

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -313,6 +314,12 @@ func pkgIndex(file, funcName string) int {
 
 var runtimePath string
 
+// In order to test TrimRuntime, we would like to
+// emulate setting the runtimePath
+func TestSetRuntimePath(runtime string) {
+	runtimePath = runtime
+}
+
 func init() {
 	var pcs [1]uintptr
 	runtime.Callers(0, pcs[:])
@@ -325,6 +332,7 @@ func init() {
 	if runtime.GOOS == "windows" {
 		runtimePath = strings.ToLower(runtimePath)
 	}
+	runtimePath = path.Join(runtimePath, "/")
 }
 
 func inGoroot(c Call) bool {

--- a/stack.go
+++ b/stack.go
@@ -314,12 +314,6 @@ func pkgIndex(file, funcName string) int {
 
 var runtimePath string
 
-// In order to test TrimRuntime, we would like to
-// emulate setting the runtimePath
-func TestSetRuntimePath(runtime string) {
-	runtimePath = runtime
-}
-
 func init() {
 	var pcs [1]uintptr
 	runtime.Callers(0, pcs[:])

--- a/stack.go
+++ b/stack.go
@@ -191,7 +191,7 @@ func (cs CallStack) MarshalText() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Format implements fmt.Formatter by printing the CallStack as square brackes
+// Format implements fmt.Formatter by printing the CallStack as square brackets
 // ([, ]) surrounding a space separated list of Calls each formatted with the
 // supplied verb and options.
 func (cs CallStack) Format(s fmt.State, verb rune) {
@@ -307,7 +307,7 @@ func pkgIndex(file, funcName string) int {
 			break
 		}
 	}
-	// get back to 0 or trim the leading seperator
+	// get back to 0 or trim the leading separator
 	return i + len(sep)
 }
 


### PR DESCRIPTION
inGoroot uses strings.HasPrefix to determine whether or not a file is inside the goroot. However, this doesn't work well if the goroot is actually a prefix of the gopath.

For example, on my machine, I use:
GOROOT=/home/alex/go
GOPATH=/home/alex/gopath

Since all the code within gopath has GOROOT as a prefix, TrimRuntime() produces empty stack traces.
This PR fixes this by ensuring GOROOT ends in a trailing /

Testing is tricky, since Callstacks are lists which contain runtime.Func objects, which cannot be created for testing. This could be remedied by having Call contain an interface instead of a runtime.Func. I'm not sure this is worthwhile for such a small change.