### PR TITLE
Refactor checks for sigpanic.

### DIFF
--- a/stackinternal_test.go
+++ b/stackinternal_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-func TestFindSigpanic(t *testing.T) {
-	t.Parallel()
-	sp := findSigpanic()
-	if got, want := sp.Name(), "runtime.sigpanic"; got != want {
-		t.Errorf("got == %v, want == %v", got, want)
-	}
-}
-
 func TestCaller(t *testing.T) {
 	t.Parallel()
 
@@ -55,7 +47,7 @@ func TestTrace(t *testing.T) {
 
 	cs := fh.labyrinth()
 
-	lines := []int{51, 41, 56}
+	lines := []int{43, 33, 48}
 
 	for i, line := range lines {
 		if got, want := cs[i].line(), line; got != want {


### PR DESCRIPTION
This commit changes the method by which the library checks for the presence
of the runtime `sigpanic` function. Instead of forcing a sigpanic to then grab
a reference to the function, we simply check for the function name. This should
be just as reliable as the alternative and does not cause unwanted interactions
with debuggers.