### PR TITLE
add %k and %+k to stack formatter

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -71,6 +71,7 @@ var ErrNoFunc = errors.New("no call stack information")
 //    %s    source file
 //    %d    line number
 //    %n    function name
+//    %k    package name
 //    %v    equivalent to %s:%d
 //
 // It accepts the '+' and '#' flags for most of the verbs as follows.
@@ -78,6 +79,7 @@ var ErrNoFunc = errors.New("no call stack information")
 //    %+s   path of source file relative to the compile time GOPATH
 //    %#s   full path of source file
 //    %+n   import path qualified function name
+//    %+k   full package path
 //    %+v   equivalent to %+s:%d
 //    %#v   equivalent to %#s:%d
 func (c Call) Format(s fmt.State, verb rune) {
@@ -111,19 +113,27 @@ func (c Call) Format(s fmt.State, verb rune) {
 		buf := [6]byte{}
 		s.Write(strconv.AppendInt(buf[:0], int64(line), 10))
 
-	case 'n':
+	case 'n', 'k':
 		name := c.fn.Name()
-		if !s.Flag('+') {
+		var path, pkg string
+		if !s.Flag('+') || verb == 'k' {
 			const pathSep = "/"
 			if i := strings.LastIndex(name, pathSep); i != -1 {
-				name = name[i+len(pathSep):]
+				path, name = name[:i], name[i+len(pathSep):]
 			}
 			const pkgSep = "."
 			if i := strings.Index(name, pkgSep); i != -1 {
-				name = name[i+len(pkgSep):]
+				pkg, name = name[:i], name[i+len(pkgSep):]
 			}
 		}
-		io.WriteString(s, name)
+		if verb == 'n' {
+			io.WriteString(s, name)
+			return
+		}
+		if s.Flag('+') && path != "" {
+			pkg = path + "/" + pkg
+		}
+		io.WriteString(s, pkg)
 	}
 }
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -40,6 +40,7 @@ func TestCallFormat(t *testing.T) {
 		t.Fatal("runtime.Caller(0) failed")
 	}
 	relFile2 := path.Join(importPath, filepath.Base(file2))
+	fullFunc := runtime.FuncForPC(pc2).Name()
 
 	data := []struct {
 		c    stack.Call
@@ -64,7 +65,9 @@ func TestCallFormat(t *testing.T) {
 		{c2, "meth", "%#s", file2},
 		{c2, "meth", "%d", fmt.Sprint(line2)},
 		{c2, "meth", "%n", "testType.testMethod"},
-		{c2, "meth", "%+n", runtime.FuncForPC(pc2).Name()},
+		{c2, "meth", "%+n", fullFunc},
+		{c2, "meth", "%k", "stack_test"},
+		{c2, "meth", "%+k", fullFunc[:strings.LastIndex(fullFunc, "/")+1] + "stack_test"},
 		{c2, "meth", "%v", fmt.Sprint(path.Base(file2), ":", line2)},
 		{c2, "meth", "%+v", fmt.Sprint(relFile2, ":", line2)},
 		{c2, "meth", "%#v", fmt.Sprint(file2, ":", line2)},


### PR DESCRIPTION
Pull from golantern/stack, revert name changes back to go-stack/stack.

Tested here and reviewed implementation. Looks like a good approach as the call to .Name() does retrieve the package, filename and other information so it seems to make sense to overload the %n handler to also handle %k.

Goal is to have this available for go-kit/log to retrieve a package name.
