### PR TITLE
Test using latest point release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 sudo: false
 go:
-  - "1.7"
-  - "1.8"
-  - "1.9"
-  - "1.10"
-  - "tip"
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - tip
 
 before_install:
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
Specifying "1.7" will test with 1.7, not with 1.7.6 or whatever. We
probably want the latter as that's the one with bug fixes and the one
people are likely to be running in production.

Also test Go 1.10.