### PR TITLE
Add module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/go-stack/stack


### PR DESCRIPTION
In addition to adding a go.mod file, this PR also updates the implementation of the `%+s` and `%+v` formats to provide semantically equivalent behavior when compiled in either a GOPATH or module based project. All existing tests still pass in both modes. I've also manually tested several cases of using this in a module aware main program and with stacks that include modules >= v2.0.0 to ensure the results are useful in those cases.

There is one subtle difference in the behavior when using modules. That is, stack frames originating in vendored packages built with the `-mod=vendor` flag will report their import path as seen in the source code rather than a path in the vendor folder of the main project. I rather like this behavior. Having paths that match the import path used in the source seems more natural, but opinions may differ here. Also note that the `%#s` and `%#v` formats still produce unmodified full paths to the compile time source locations as always.

