### PR TITLE
add TraceFrom(pcs) for "on-demand" StackTrace instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GoDoc](https://godoc.org/github.com/go-stack/stack?status.svg)](https://godoc.org/github.com/go-stack/stack)
+[![GoDoc](https://godoc.org/github.com/eluv-io/stack?status.svg)](https://godoc.org/github.com/eluv-io/stack)
 [![Go Report Card](https://goreportcard.com/badge/go-stack/stack)](https://goreportcard.com/report/go-stack/stack)
 [![TravisCI](https://travis-ci.org/go-stack/stack.svg?branch=master)](https://travis-ci.org/go-stack/stack)
 [![Coverage Status](https://coveralls.io/repos/github/go-stack/stack/badge.svg?branch=master)](https://coveralls.io/github/go-stack/stack?branch=master)

--- a/format_test.go
+++ b/format_test.go
@@ -5,7 +5,7 @@ package stack_test
 import (
 	"fmt"
 
-	"github.com/go-stack/stack"
+	"github.com/eluv-io/stack"
 )
 
 func Example_callFormat() {

--- a/format_test.go
+++ b/format_test.go
@@ -12,7 +12,7 @@ func Example_callFormat() {
 	logCaller("%+s")
 	logCaller("%v   %[1]n()")
 	// Output:
-	// github.com/go-stack/stack/format_test.go
+	// github.com/eluv-io/stack/format_test.go
 	// format_test.go:13   Example_callFormat()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/eluv-io/stack
+
+go 1.9

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/go-stack/stack
+module github.com/eluv-io/stack

--- a/stack-go19_test.go
+++ b/stack-go19_test.go
@@ -38,7 +38,7 @@ func TestCallerInlinedPanic(t *testing.T) {
 			}
 
 			c1 := stack.Caller(panicIdx + 1)
-			if got, want := c1.Frame().Function, "github.com/go-stack/stack_test.inlinablePanic"; got != want {
+			if got, want := c1.Frame().Function, "github.com/eluv-io/stack_test.inlinablePanic"; got != want {
 				t.Errorf("TestCallerInlinedPanic frame: got name == %v, want name == %v", got, want)
 			}
 			if got, want := c1.Frame().Line, line; got != want {

--- a/stack-go19_test.go
+++ b/stack-go19_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-stack/stack"
+	"github.com/eluv-io/stack"
 )
 
 func TestCallerInlinedPanic(t *testing.T) {

--- a/stack.go
+++ b/stack.go
@@ -208,14 +208,24 @@ func (cs CallStack) Format(s fmt.State, verb rune) {
 	s.Write(closeBracketBytes)
 }
 
+// Convenience wrapper around runtime.Callers()
+func Callers(skip int) []uintptr {
+	var pcs [512]uintptr
+	n := runtime.Callers(skip, pcs[:])
+	return pcs[:n]
+}
+
 // Trace returns a CallStack for the current goroutine with element 0
 // identifying the calling function.
 func Trace() CallStack {
-	var pcs [512]uintptr
-	n := runtime.Callers(1, pcs[:])
+	return TraceFrom(Callers(2))
+}
 
-	frames := runtime.CallersFrames(pcs[:n])
-	cs := make(CallStack, 0, n)
+// TraceFrom creates a CallStack from the given program counters (as generated
+// by runtime.Callers)
+func TraceFrom(pcs []uintptr) CallStack {
+	frames := runtime.CallersFrames(pcs)
+	cs := make(CallStack, 0, len(pcs))
 
 	// Skip extra frame retrieved just to make sure the runtime.sigpanic
 	// special case is handled.

--- a/stack.go
+++ b/stack.go
@@ -211,14 +211,14 @@ func (cs CallStack) Format(s fmt.State, verb rune) {
 // Convenience wrapper around runtime.Callers()
 func Callers(skip int) []uintptr {
 	var pcs [512]uintptr
-	n := runtime.Callers(skip, pcs[:])
+	n := runtime.Callers(skip+1, pcs[:])
 	return pcs[:n]
 }
 
 // Trace returns a CallStack for the current goroutine with element 0
 // identifying the calling function.
 func Trace() CallStack {
-	return TraceFrom(Callers(2))
+	return TraceFrom(Callers(1))
 }
 
 // TraceFrom creates a CallStack from the given program counters (as generated

--- a/stack_test.go
+++ b/stack_test.go
@@ -56,7 +56,7 @@ func TestCallerMidstackInlined(t *testing.T) {
 	if got, want := c.Frame().Line, line; got != want {
 		t.Errorf("got line == %v, want line == %v", got, want)
 	}
-	if got, want := c.Frame().Function, "github.com/go-stack/stack_test.f3"; got != want {
+	if got, want := c.Frame().Function, "github.com/eluv-io/stack_test.f3"; got != want {
 		t.Errorf("got func name == %v, want func name == %v", got, want)
 	}
 }
@@ -91,7 +91,7 @@ func TestCallerPanic(t *testing.T) {
 				t.Errorf("sigpanic frame: got name == %v, want name == %v", got, want)
 			}
 			c1 := stack.Caller(panicIdx + 1)
-			if got, want := c1.Frame().Function, "github.com/go-stack/stack_test.TestCallerPanic"; got != want {
+			if got, want := c1.Frame().Function, "github.com/eluv-io/stack_test.TestCallerPanic"; got != want {
 				t.Errorf("TestCallerPanic frame: got name == %v, want name == %v", got, want)
 			}
 			if got, want := c1.Frame().Line, line; got != want {
@@ -173,7 +173,7 @@ func TestTracePanic(t *testing.T) {
 			if got, want := trace[panicIdx].Frame().Function, "runtime.sigpanic"; got != want {
 				t.Errorf("sigpanic frame: got name == %v, want name == %v", got, want)
 			}
-			if got, want := trace[panicIdx+1].Frame().Function, "github.com/go-stack/stack_test.TestTracePanic"; got != want {
+			if got, want := trace[panicIdx+1].Frame().Function, "github.com/eluv-io/stack_test.TestTracePanic"; got != want {
 				t.Errorf("TestTracePanic frame: got name == %v, want name == %v", got, want)
 			}
 			if got, want := trace[panicIdx+1].Frame().Line, line; got != want {
@@ -192,7 +192,7 @@ func TestTracePanic(t *testing.T) {
 	_ = *x
 }
 
-const importPath = "github.com/go-stack/stack"
+const importPath = "github.com/eluv-io/stack"
 
 type testType struct{}
 
@@ -233,9 +233,9 @@ func TestCallFormat(t *testing.T) {
 		{c, "func", "%#s", file},
 		{c, "func", "%d", fmt.Sprint(line)},
 		{c, "func", "%n", "TestCallFormat"},
-		{c, "func", "%+n", "github.com/go-stack/stack_test.TestCallFormat"},
+		{c, "func", "%+n", "github.com/eluv-io/stack_test.TestCallFormat"},
 		{c, "func", "%k", "stack_test"},
-		{c, "func", "%+k", "github.com/go-stack/stack_test"},
+		{c, "func", "%+k", "github.com/eluv-io/stack_test"},
 		{c, "func", "%v", fmt.Sprint(path.Base(file), ":", line)},
 		{c, "func", "%+v", fmt.Sprint(relFile, ":", line)},
 		{c, "func", "%#v", fmt.Sprint(file, ":", line)},
@@ -245,9 +245,9 @@ func TestCallFormat(t *testing.T) {
 		{c2, "meth", "%#s", file2},
 		{c2, "meth", "%d", fmt.Sprint(line2)},
 		{c2, "meth", "%n", "testType.testMethod"},
-		{c2, "meth", "%+n", "github.com/go-stack/stack_test.testType.testMethod"},
+		{c2, "meth", "%+n", "github.com/eluv-io/stack_test.testType.testMethod"},
 		{c2, "meth", "%k", "stack_test"},
-		{c2, "meth", "%+k", "github.com/go-stack/stack_test"},
+		{c2, "meth", "%+k", "github.com/eluv-io/stack_test"},
 		{c2, "meth", "%v", fmt.Sprint(path.Base(file2), ":", line2)},
 		{c2, "meth", "%+v", fmt.Sprint(relFile2, ":", line2)},
 		{c2, "meth", "%#v", fmt.Sprint(file2, ":", line2)},

--- a/stack_test.go
+++ b/stack_test.go
@@ -497,6 +497,14 @@ func deepStack(depth int, b *testing.B) stack.CallStack {
 	return s
 }
 
+func deepCallers(depth int, b *testing.B) []uintptr {
+	if depth > 0 {
+		return deepCallers(depth-1, b)
+	}
+	b.StartTimer()
+	return stack.Callers(1)
+}
+
 func BenchmarkTrace10(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -515,6 +523,33 @@ func BenchmarkTrace100(b *testing.B) {
 	b.StopTimer()
 	for i := 0; i < b.N; i++ {
 		deepStack(100, b)
+	}
+}
+
+func BenchmarkCallers(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		stack.Callers(1)
+	}
+}
+
+func BenchmarkCallers10(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		deepCallers(10, b)
+	}
+}
+
+func BenchmarkCallers50(b *testing.B) {
+	b.StopTimer()
+	for i := 0; i < b.N; i++ {
+		deepCallers(50, b)
+	}
+}
+
+func BenchmarkCallers100(b *testing.B) {
+	b.StopTimer()
+	for i := 0; i < b.N; i++ {
+		deepCallers(100, b)
 	}
 }
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-stack/stack"
+	"github.com/eluv-io/stack"
 )
 
 func TestCaller(t *testing.T) {


### PR DESCRIPTION
Allows to record just the pcs from runtime.Callers when an error
occurs and convert them to a StackTrace only if the trace is actually
needed, e.g. when printing to a log.

Improves performance about 4x.